### PR TITLE
Fix: Offset error in Disable Air mode

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -328,7 +328,7 @@ void InputReceive(SOCKET sHost, char *memory)
         }
         else if(real_len >= 3 + 4 + 32 && buffer[1] == 'I' && buffer[2] == 'P' && buffer[3] == 'T') /// without air block
         {
-            memcpy(memory, buffer + 4, 32);
+            memcpy(memory + 6, buffer + 4 + 4, 32);
             if(real_len > 3 + 4 + 32)
             {
                 memcpy(memory + 6 + 32 + 96, buffer + 4 + 4 + 32, real_len - (3 + 32 + 4));


### PR DESCRIPTION
In Disable Air mode,
Since there are no air data, the slider data should be copied to `memory + 6` instead of `memory + 0`, otherwise it will replace the air data
And the slider data in the buffer starts at `buffer + 8` instead of `buffer + 4`

There's also a bug in the Android app. I've created a pull request [there](https://github.com/tindy2013/Brokenithm-Android/pull/1) too.

After those patches, now it works flawlessly with [chuni-hands](https://github.com/logchan/chuni-hands)!